### PR TITLE
Add ForgeMap as an AutoMapper alternative

### DIFF
--- a/content/libraries/automapper.mdx
+++ b/content/libraries/automapper.mdx
@@ -54,7 +54,12 @@ The news prompted discussions about alternatives ([Source](https://www.reddit.co
     *   **Pros**: High performance, flexible, and type-safe.
     *   **Cons**: Requires manual updates if object structures change.
 
-3.  **Manual Mapping**:
+3. **[ForgeMap](https://github.com/superyyrrzz/ForgeMap)**:
+    *   A lightweight .NET source generator for object mapping. Compile-time code generation with zero reflection.
+    *   **Pros**: Fastest in benchmarks against AutoMapper and Mapperly, zero runtime reflection, compile-time type safety with 27 diagnostics, debuggable generated code. Licensed under MIT. Available on [NuGet](https://www.nuget.org/packages/ForgeMap).
+    *   **Cons**: Newer project, smaller community compared to Mapperly or Mapster.
+
+4.  **Manual Mapping**:
     *   Simply writing the mapping code directly in C#.
     *   **Pros**: Maximum control, no external dependency, clear and debuggable code. Often considered simpler in the long run despite initial boilerplate.
     *   **Cons**: Can involve writing repetitive code, requires manual updates if object structures change.
@@ -75,3 +80,4 @@ AutoMapper's transition to a commercial model is now complete, providing a clear
 *   Reddit: [Migrate out of automapper?](https://www.reddit.com/r/dotnet/comments/1h2cy10/migrate_out_of_automapper/)
 *   Alternative: [Mapperly](https://github.com/riok/mapperly)
 *   Alternative: [Mapster](https://github.com/MapsterMapper/Mapster)
+*   Alternative: [ForgeMap](https://github.com/superyyrrzz/ForgeMap)

--- a/src/data/summary.json
+++ b/src/data/summary.json
@@ -28,7 +28,7 @@
     "newLicense": "Commercial",
     "pricing": "TBD",
     "lastFreeVersion": "Current",
-    "alternatives": ["Mapperly", "Mapster", "manual mapping"],
+    "alternatives": ["Mapperly", "Mapster", "ForgeMap", "manual mapping"],
     "websiteUrl": "https://automapper.org/",
     "websiteText": "automapper.org"
   },


### PR DESCRIPTION
## Summary

- Adds [ForgeMap](https://github.com/superyyrrzz/ForgeMap) as an alternative to AutoMapper in both the library page and summary table
- ForgeMap is an MIT-licensed Roslyn source generator for .NET object mapping with zero runtime reflection
- [Fastest in benchmarks](https://github.com/superyyrrzz/ForgeMap/blob/main/benchmarks/BENCHMARK_RESULTS.md) against AutoMapper and Mapperly (.NET 9)

## Changes

- `content/libraries/automapper.mdx`: Added ForgeMap entry under Alternatives and Links
- `src/data/summary.json`: Added ForgeMap to the AutoMapper alternatives array